### PR TITLE
Add IFocusMenuExtension extension

### DIFF
--- a/src/CSSUniversalMenuAPI/Extensions/IFocusMenuExtension.cs
+++ b/src/CSSUniversalMenuAPI/Extensions/IFocusMenuExtension.cs
@@ -1,0 +1,29 @@
+namespace CSSUniversalMenuAPI.Extensions;
+
+/// <summary>
+/// Allow a menu or a notification to be presented to a player, but without taking focus from the player. <br/>
+/// This should be used when you want to present a menu to a player who may not be expecting it, such as votes.
+/// </summary>
+public interface IFocusMenuExtension
+{
+	/// <summary>
+	/// When <c>true</c>, the menu shall open in a state where the player can see it, or see a notification,
+	/// but require further action to be manipulate. It is expected that this would be a key that requires pressing
+	/// to toggle the menu.<br/>
+	///<br/>
+	/// Implementations should default this value to <c>true</c>.
+	/// </summary>
+	bool OpenWithFocus { get; set; }
+
+	/// <summary>
+	/// Returns whether or not the player's input is to be received by this menu if it were visible. <br/>
+	/// Whether the menu is being occluded by another menu should have no bearing on this value.
+	/// </summary>
+	bool HasFocus { get; }
+
+	/// <summary>
+	/// Returns whether or not this menu's input has never been focused, enabling scenarios such as timing out a menu if
+	/// it has received no interaction from the player.
+	/// </summary>
+	bool NeverHadFocus { get; }
+}


### PR DESCRIPTION
This will allow plugins to express that a menu should not take focus away from a player without the player doing something to enable that focus.

Also included is the ability to query its focus state, for whether you want to time a menu out in the case it has never been focused or such.

- [ ] Await input/consensus from other developers